### PR TITLE
Update lib/merit/controller_extensions.rb

### DIFF
--- a/lib/merit/controller_extensions.rb
+++ b/lib/merit/controller_extensions.rb
@@ -45,7 +45,7 @@ module Merit
     def target_id
       target_id = params[:id] || target_object.try(:id)
       # using friendly_id if id is nil or string but an object was found
-      if target_object.present? && (target_id.nil? || !(target_id =~ /^[0-9]+$/))
+      if target_object.present? && (target_id.nil? || !(target_id.to_s =~ /^[0-9]+$/))
         target_id = target_object.id
       end
       target_id


### PR DESCRIPTION
In line 48 of lib/merit/controller_extensions.rb, target_id is being 
evaluated by a regular expression. However, if target_id happens to 
be of type Fixnum or something other than a string type, nil will be 
returned. As nil is falsey, !(nil) evaluates to true, which can lead 
to the statement on line 49 being run undesirably. My change is a 
simple one: cast target_id as a string so it can be properly 
evaluated by the regular expression. This should eliminate the fringe 
case I encountered. Thanks.
