### PR TITLE
Use https for rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       ambry (~> 0.3.0)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     actionmailer (3.2.3)
       actionpack (= 3.2.3)


### PR DESCRIPTION
Not sure what's up with rubygems, but I can't `bundle` without https. Either way, https should be used.
