### PR TITLE
target_id in ControllerExtensions

### DIFF
--- a/lib/merit/controller_extensions.rb
+++ b/lib/merit/controller_extensions.rb
@@ -43,12 +43,11 @@ module Merit
     end
 
     def target_id
-      target_id = params[:id] || target_object.try(:id)
-      # If params[:id] is a string (slug, using friendly_id for instance)
-      # then object exists but can't store params[:id] as the foreign key.
-      # Then we grab object's id.
-      if target_object && (target_id.nil? || !(target_id.to_s =~ /^[0-9]+$/))
-        target_id = target_object.id
+      target_id = target_object.try(:id)
+      # If target_id is nil
+      # then use params[:id].
+      if target_id.nil? && params[:id].to_s =~ /^[0-9]+$/
+        target_id = params[:id]
       end
       target_id
     end


### PR DESCRIPTION
In ControllerExtensions, the target_id will be assigned params[:id] first, and will be assigned target_object's id if params[:id] is illegal. But I think target_id should be target_object's id first, because params[:id] is depend on external environment, anybody can pass a param to make the app wrong. 
