### PR TITLE
Allow disable automatically added after_filter

### DIFF
--- a/lib/generators/merit/templates/merit.rb
+++ b/lib/generators/merit/templates/merit.rb
@@ -11,6 +11,14 @@ Merit.setup do |config|
 
   # Define :current_user_method. Similar to previous option. It will be used to retrieve :user_model_name object if no :to option is given. Default is "current_#{user_model_name.downcase}".
   # config.current_user_method = "current_user"
+
+  # Define: use_automatic_after_filter
+  # Default is to use automatic after_filter, enabling Merit to log actions behind the scene
+  # If disabled, you can call method 'merit_check_and_process' manually in controller,
+  # either inside an action say after saving success, or as a custom
+  # after_filter like: `after_filter :merit_check_and_process, only: [:create, :update]
+  # config.use_automatic_after_filter = true
+  
 end
 
 # Create application badges (uses https://github.com/norman/ambry)

--- a/lib/merit.rb
+++ b/lib/merit.rb
@@ -32,6 +32,10 @@ module Merit
     @@current_user_method || "current_#{@@user_model_name.downcase}".to_sym
   end
 
+  # Using automatic after_filter on controller
+  mattr_accessor :use_automatic_after_filter
+  @@use_automatic_after_filter = true
+
 
   # Load configuration from initializer
   def self.setup

--- a/lib/merit/controller_extensions.rb
+++ b/lib/merit/controller_extensions.rb
@@ -3,14 +3,13 @@ module Merit
   # there are defined rules (for badges or points) for current
   # 'controller_path#action_name'
   module ControllerExtensions
-    # def self.included(base)
-    #   base.after_filter do |controller|
-    #     if rules_defined?
-    #       log_merit_action
-    #       Merit::Action.check_unprocessed if Merit.checks_on_each_request
-    #     end
-    #   end
-    # end
+    def self.included(base)
+      if Merit.use_automatic_after_filter
+        base.after_filter do |controller|
+          merit_check_and_process
+        end
+      end
+    end
 
     def merit_check_and_process
       if rules_defined?


### PR DESCRIPTION
Hi, @tute,

Sometimes I found it needed to disable the default after_filter in controller and add it manually instead. So I added a config option to allow disabling it when needed.
### Use case 1

The app is a heavy read app so I don't want to Merit to check unnecessary actions like `show` and `index`. Instead, I can define the after_filter by myself for limited actions.

``` ruby
after_filter :merit_check_and_process, only: [:create, :update]
```
### Use case 2

If using JSON or UJS to response, developer may want to output the new user points right in this request. If all Merit logic happens after render, there is no way to show new points. So it can be used like this(without any after_filter)

``` ruby
if @comment.save
  merit_check_and_process
```

Then the points on JSON or js template will be the new one.
### Use case 3

I'm still not sure, I would like to output points delta withing the request in the future. I read your idea on #97, but the query looks complex. I read the source and found it should be possible to fetch delta after Judge, and return it during request, though not sure yet. But separating after_filter sounds the first step. Would like to hear your advise.

Thanks for your consideration!
