### PR TITLE
Check for several gem combinations

### DIFF
--- a/lib/merit/models/active_record/merit/action.rb
+++ b/lib/merit/models/active_record/merit/action.rb
@@ -4,7 +4,7 @@ module Merit
 
     has_many :activity_logs, class_name: Merit::ActivityLog
 
-    unless defined?(ActionController::StrongParameters)
+    if defined?(ProtectedAttributes) || !defined?(ActionController::StrongParameters)
       attr_accessible :user_id, :action_method, :action_value, :had_errors,
         :target_model, :target_id, :processed, :log
     end

--- a/lib/merit/models/active_record/merit/activity_log.rb
+++ b/lib/merit/models/active_record/merit/activity_log.rb
@@ -5,7 +5,7 @@ module Merit
     belongs_to :action, class_name: Merit::Action
     belongs_to :related_change, polymorphic: true
 
-    unless defined?(ActionController::StrongParameters)
+    if defined?(ProtectedAttributes) || !defined?(ActionController::StrongParameters)
       attr_accessible :action_id, :related_change, :description, :created_at
     end
   end

--- a/lib/merit/models/active_record/merit/badges_sash.rb
+++ b/lib/merit/models/active_record/merit/badges_sash.rb
@@ -5,7 +5,7 @@ module Merit
       class_name: Merit::ActivityLog,
       as: :related_change
 
-    unless defined?(ActionController::StrongParameters)
+    if defined?(ProtectedAttributes) || !defined?(ActionController::StrongParameters)
       attr_accessible :badge_id
     end
 


### PR DESCRIPTION
For #116 and #132.

`ProtectedAttributes` is defined only if you add the corresponding gem, not
if you use rails 3 without the gem. If you use rails 3 **and**
`strong_parameters`, or if you use rails 4, you have defined
`ActionController::StrongParameters`. If you use rails 4 **and**
`protected_attributes` you do have defined `ActionController::StrongParameters`,
but also `ProtectedAttributes` so it should short-circuit, right?

So I **think** these conditions satisfy every case. But I have no tests for
this. Although it should be possible to load different Gemfiles for each test
case, I don't know if it's worth the trouble..

What do you think?
