### PR TITLE
Updates documentation to be more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Status](https://coveralls.io/repos/tute/merit/badge.png?branch=master)](https://
 # Installation
 
 1. Add `gem 'merit'` to your `Gemfile`
-2. Run `rails g merit:install`
-3. Run `rails g merit MODEL_NAME` (e.g. `user`) and add `has_merit` to MODEL_NAME
+2. Run `rails g merit:install`. This creates several migrations.
+3. Run `rails g merit MODEL_NAME` (e.g. `user`). This creates a migration and adds `has_merit` to MODEL_NAME.
 4. Run `rake db:migrate`
 5. Define badges in `config/initializers/merit.rb`. You can also define ORM:
    `:active_record` (default) or `:mongoid`.


### PR DESCRIPTION
It took me a bit to realize that `has_merit` needs to be added to the model, since it's not in the installation instructions.

I also changed "Yearling" to "year-member", since it demonstrates the actual convention for naming badges.

Also one typo.
