### PR TITLE
namespace Badge calls inside of Merit. 

### DIFF
--- a/app/models/merit/badge.rb
+++ b/app/models/merit/badge.rb
@@ -36,7 +36,7 @@ module Merit
 
     class << self
       def find_by_name_and_level(name, level)
-        badges = Badge.by_name(name)
+        badges = Merit::Badge.by_name(name)
         badges = badges.by_level(level) unless level.nil?
         if (badge = badges.first).nil?
           str = "No badge '#{name}' found. Define it in initializers/merit.rb"

--- a/lib/merit/model_additions.rb
+++ b/lib/merit/model_additions.rb
@@ -35,7 +35,7 @@ module Merit
 
     def _merit_define_badge_related_entries_method
       meritable_class_name = name.demodulize
-      Badge._define_related_entries_method(meritable_class_name)
+      Merit::Badge._define_related_entries_method(meritable_class_name)
     end
 
     def show_attr_accessible?

--- a/lib/merit/models/base/badges_sash.rb
+++ b/lib/merit/models/base/badges_sash.rb
@@ -8,7 +8,7 @@ module Merit
       end
 
       def badge
-        Badge.find(badge_id)
+        Merit::Badge.find(badge_id)
       end
     end
   end

--- a/lib/merit/rule.rb
+++ b/lib/merit/rule.rb
@@ -25,7 +25,7 @@ module Merit
 
     # Get rule's related Badge.
     def badge
-      @badge ||= Badge.find_by_name_and_level(badge_name, level)
+      @badge ||= Merit::Badge.find_by_name_and_level(badge_name, level)
     end
   end
 end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -26,7 +26,7 @@ class User
   end
 
   def show_badges
-    badges_uniq = Badge.find_by_id(badge_ids)
+    badges_uniq = Merit::Badge.find_by_id(badge_ids)
     badges_uniq.collect{|b| "#{b.name.capitalize}#{badge_status(b)}" }.join(', ')
   end
 


### PR DESCRIPTION
Prevents errors if the app using merit has a model named Badge, as seen in #183
