### PR TITLE
[change_migrations_to_use_change_method] Change method ActiveRecord::Migration :up/:down to use :change.

### DIFF
--- a/lib/generators/active_record/templates/add_fields_to_model.rb
+++ b/lib/generators/active_record/templates/add_fields_to_model.rb
@@ -1,12 +1,6 @@
 class AddFieldsTo<%= table_name.camelize %> < ActiveRecord::Migration
-  def self.up
+  def change
     add_column :<%= table_name %>, :sash_id, :integer
-    add_column :<%= table_name %>, :level, :integer, :default => 0
-    <%- resource = table_name.singularize -%>
-  end
-
-  def self.down
-    remove_column :<%= table_name %>, :sash_id
-    remove_column :<%= table_name %>, :level
+    add_column :<%= table_name %>, :level,   :integer, :default => 0
   end
 end

--- a/lib/generators/active_record/templates/create_merit_actions.rb
+++ b/lib/generators/active_record/templates/create_merit_actions.rb
@@ -1,5 +1,5 @@
 class CreateMeritActions < ActiveRecord::Migration
-  def self.up
+  def change
     create_table :merit_actions do |t|
       t.integer :user_id
       t.string  :action_method
@@ -11,9 +11,5 @@ class CreateMeritActions < ActiveRecord::Migration
       t.boolean :processed, default: false
       t.timestamps
     end
-  end
-
-  def self.down
-    drop_table :merit_actions
   end
 end

--- a/lib/generators/active_record/templates/create_merit_activity_logs.rb
+++ b/lib/generators/active_record/templates/create_merit_activity_logs.rb
@@ -1,5 +1,5 @@
 class CreateMeritActivityLogs < ActiveRecord::Migration
-  def self.up
+  def change
     create_table :merit_activity_logs do |t|
       t.integer  :action_id
       t.string   :related_change_type
@@ -7,9 +7,5 @@ class CreateMeritActivityLogs < ActiveRecord::Migration
       t.string   :description
       t.datetime :created_at
     end
-  end
-
-  def self.down
-    drop_table :merit_activity_logs
   end
 end

--- a/lib/generators/active_record/templates/create_sashes.rb
+++ b/lib/generators/active_record/templates/create_sashes.rb
@@ -1,11 +1,7 @@
 class CreateSashes < ActiveRecord::Migration
-  def self.up
+  def change
     create_table :sashes do |t|
       t.timestamps
     end
-  end
-
-  def self.down
-    drop_table :sashes
   end
 end

--- a/lib/generators/active_record/templates/create_scores_and_points.rb
+++ b/lib/generators/active_record/templates/create_scores_and_points.rb
@@ -1,5 +1,5 @@
 class CreateScoresAndPoints < ActiveRecord::Migration
-  def self.up
+  def change
     create_table :merit_scores do |t|
       t.references :sash
       t.string :category, default: 'default'
@@ -11,10 +11,5 @@ class CreateScoresAndPoints < ActiveRecord::Migration
       t.string :log
       t.datetime :created_at
     end
-  end
-
-  def self.down
-    drop_table :merit_scores
-    drop_table :merit_score_points
   end
 end


### PR DESCRIPTION
As described in https://github.com/bbatsov/rails-style-guide#migrations.
- http://api.rubyonrails.org/v3.2.0/classes/ActiveRecord/Migration.html#Revesible+Migrations
