### PR TITLE
Allow Rule to find Badge by `:badge_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ are no longer met).
 Badge rules / conditions are defined in `app/models/merit/badge_rules.rb`
 `initialize` block by calling `grant_on` with the following parameters:
 
-* `'controller#action'` a string similar to Rails routes
-* `:badge` corresponds to the `:name` of the badge
+* `'controller#action'` a string similar to Rails routes (required)
+* `:badge_id` or `:badge` these correspond to the `:id` or `:name` of the badge respectively
 * `:level` corresponds to the `:level` of the badge
 * `:to` the object's field to give the badge to. It needs a variable named
   `@model` in the associated controller action, like `@post` for
@@ -103,7 +103,7 @@ Badge rules / conditions are defined in `app/models/merit/badge_rules.rb`
 
 ```ruby
 # app/models/merit/badge_rules.rb
-grant_on 'comments#vote', badge: 'relevant-commenter', to: :user do |comment|
+grant_on 'comments#vote', badge_id: 5, to: :user do |comment|
   comment.votes.count == 5
 end
 

--- a/lib/generators/merit/templates/merit_badge_rules.rb
+++ b/lib/generators/merit/templates/merit_badge_rules.rb
@@ -23,7 +23,8 @@ module Merit
     def initialize
       # If it creates user, grant badge
       # Should be "current_user" after registration for badge to be granted.
-      # grant_on 'users#create', badge: 'just-registered', to: :itself
+      # Find badge by badge_id, badge_id takes presidence over badge
+      # grant_on 'users#create', badge_id: 7, badge: 'just-registered', to: :itself
 
       # If it has 10 comments, grant commenter-10 badge
       # grant_on 'comments#create', badge: 'commenter', level: 10 do |comment|

--- a/lib/merit/rule.rb
+++ b/lib/merit/rule.rb
@@ -3,7 +3,7 @@ module Merit
   # and a temporary option.
   # Could split this class between badges and rankings functionality
   class Rule
-    attr_accessor :badge_name, :level, :to, :model_name, :level_name,
+    attr_accessor :badge_id, :badge_name, :level, :to, :model_name, :level_name,
                   :multiple, :temporary, :score, :block, :category
 
     # Does this rule's condition block apply?
@@ -25,7 +25,11 @@ module Merit
 
     # Get rule's related Badge.
     def badge
-      @badge ||= Merit::Badge.find_by_name_and_level(badge_name, level)
+      if badge_id
+        Merit::Badge.find(badge_id)
+      else
+        Merit::Badge.find_by_name_and_level(badge_name, level)
+      end
     end
   end
 end

--- a/lib/merit/rules_badge_methods.rb
+++ b/lib/merit/rules_badge_methods.rb
@@ -7,6 +7,7 @@ module Merit
       actions = Array.wrap(actions)
 
       rule = Rule.new
+      rule.badge_id   = options[:badge_id]
       rule.badge_name = options[:badge]
       rule.level      = options[:level]
       rule.to         = options[:to] || :action_user

--- a/test/dummy/app/models/merit/badge_rules.rb
+++ b/test/dummy/app/models/merit/badge_rules.rb
@@ -42,8 +42,8 @@ module Merit
       # Example rule for testing badge granting in differently namespaced controllers.
       grant_on '.*users#index', badge: 'wildcard_badge', multiple: true
 
-      # If it has 10 comments, grant commenter-10 badge
-      grant_on 'comments#create', badge: 'commenter', level: 10 do |comment|
+      # If it has 10 comments, grant commenter-10 badge, find badge by badge_id
+      grant_on 'comments#create', badge_id: 1, level: 10 do |comment|
         comment.user.comments.count >= 10
       end
       # Testing badge granting in more than one rule per action with different targets

--- a/test/unit/rule_unit_test.rb
+++ b/test/unit/rule_unit_test.rb
@@ -35,9 +35,15 @@ describe Merit::Rule do
       -> { @rule.badge }.must_raise Merit::BadgeNotFound
     end
 
-    it 'finds related badge' do
-      badge = Merit::Badge.create(id: 98, name: 'test-badge-98')
-      @rule.badge_name = badge.name
+    it 'finds related badge by name' do
+      Merit::Badge.create(id: 98, name: 'test-badge-98')
+      @rule.badge_name = "test-badge-98"
+      @rule.badge.must_be :==, Merit::Badge.find(98)
+    end
+
+    it 'finds related badge by name' do
+      Merit::Badge.create(id: 98, name: 'test-badge-98')
+      @rule.badge_id = 98
       @rule.badge.must_be :==, Merit::Badge.find(98)
     end
   end


### PR DESCRIPTION
I want to be able to edit Badge name and descriptions in my database, unfortunately by using a finder which relies on badge name I can’t easily modify badges without using a separate locked db column just to support the merit badge string name id.  Since IDs in relational databases aren’t modified it makes more sense to write the rules using attributes that aren’t going to be changing.  Merit badges have assigned IDs and already have a finder so I just modified the Rule class a little to support an added `:badge_id` attribute.

As it is a single attribute I set the finder to check for it first and use it for finding the badge if it is available, if not the finder falls back to `:find_by_name_and_level`
- Added `:badge_id` attribute to `Rule`
- Modified badge finder method to prefer `:badge_id` over `:badge_name` and `:level`
- Added test for Rule to support modified finder
- Added test for dummy app to support modified finder
- Documented use in badge rule template
- Documented use in README

The new use case would look something like this where `:badge_id` is the preferred finder attribute

``` ruby
#config/initializers/merit.rb
Badge.all.each do |badge|
  Merit::Badge.create(
    id: badge.id,
    name: badge.name,
    level: 0,
    description: badge.description)
end

#app/models/merit/badge_rules.rb
# If it has 10 comments, grant commenter-10 badge, find badge by badge_id
grant_on 'comments#create', badge_id: 1, badge: 'commenter', level: 10 do |comment|
  comment.user.comments.count >= 10
end
```
