### PR TITLE
find target_object by  the instance variable named model_name

### DIFF
--- a/lib/merit/controller_extensions.rb
+++ b/lib/merit/controller_extensions.rb
@@ -52,7 +52,8 @@ module Merit
     end
 
     def target_object
-      target_obj = instance_variable_get(:"@#{controller_name.singularize}") || instance_variable_get(:"@#{@rule.model_name.demodulize.underscore}")
+      target_obj = instance_variable_get(:"@#{controller_name.singularize}") ||
+                   instance_variable_get(:"@#{@rule.model_name.demodulize.underscore}") if @rule.model_name
       if target_obj.nil?
         str = '[merit] No object found, you might need a ' \
           "'@#{controller_name.singularize}' variable in " \

--- a/lib/merit/controller_extensions.rb
+++ b/lib/merit/controller_extensions.rb
@@ -6,6 +6,7 @@ module Merit
     def self.included(base)
       base.after_filter do |controller|
         if rules_defined?
+          @rule = rule
           log_merit_action
           Merit::Action.check_unprocessed if Merit.checks_on_each_request
         end
@@ -38,6 +39,10 @@ module Merit
       end
     end
 
+    def rule
+      RulesMatcher.new(controller_path, action_name).select_rule
+    end
+
     def rules_defined?
       RulesMatcher.new(controller_path, action_name).any_matching?
     end
@@ -47,7 +52,7 @@ module Merit
     end
 
     def target_object
-      target_obj = instance_variable_get(:"@#{controller_name.singularize}")
+      target_obj = instance_variable_get(:"@#{controller_name.singularize}") || instance_variable_get(:"@#{@rule.model_name.demodulize.underscore}")
       if target_obj.nil?
         str = '[merit] No object found, you might need a ' \
           "'@#{controller_name.singularize}' variable in " \

--- a/lib/merit/rules_matcher.rb
+++ b/lib/merit/rules_matcher.rb
@@ -15,6 +15,10 @@ module Merit
       select_from(AppBadgeRules).any? || select_from(AppPointRules).any?
     end
 
+    def select_rule
+      select_from(AppBadgeRules).first || select_from(AppPointRules).first
+    end
+
     private
 
     def entire_path


### PR DESCRIPTION
To read it from the controller merit searches for the instance variable named :model_name.demodulize.underscore. For example, a rule like:
```ruby
      score 10, on: 'checkout#update', model_name: 'Spree::Order' do |order|
        order.completed?
      end
```
Would make merit try to find the @order instance variable in the CheckoutController#update action.