### PR TITLE
Rename add/remove fields migrations to clarify intent

### DIFF
--- a/lib/generators/active_record/merit_generator.rb
+++ b/lib/generators/active_record/merit_generator.rb
@@ -13,8 +13,8 @@ module ActiveRecord
       end
 
       def copy_migrations_and_model
-        migration_template 'add_fields_to_model.rb',
-                           "db/migrate/add_fields_to_#{table_name}.rb"
+        migration_template 'add_merit_fields_to_model.rb',
+                           "db/migrate/add_merit_fields_to_#{table_name}.rb"
       end
     end
   end

--- a/lib/generators/active_record/remove_generator.rb
+++ b/lib/generators/active_record/remove_generator.rb
@@ -16,8 +16,10 @@ module ActiveRecord
         migration_template 'remove_merit_tables.rb',
                            'db/migrate/remove_merit_tables.rb'
 
-        migration_template 'remove_fields_from_model.rb',
-                           "db/migrate/remove_fields_from_#{table_name}.rb"
+        migration_template(
+          'remove_merit_fields_from_model.rb',
+          "db/migrate/remove_merit_fields_from_#{table_name}.rb"
+        )
       end
     end
   end

--- a/lib/generators/active_record/templates/add_merit_fields_to_model.rb
+++ b/lib/generators/active_record/templates/add_merit_fields_to_model.rb
@@ -1,4 +1,4 @@
-class AddFieldsTo<%= table_name.camelize %> < ActiveRecord::Migration
+class AddMeritFieldsTo<%= table_name.camelize %> < ActiveRecord::Migration
   def change
     add_column :<%= table_name %>, :sash_id, :integer
     add_column :<%= table_name %>, :level,   :integer, :default => 0

--- a/lib/generators/active_record/templates/remove_merit_fields_from_model.rb
+++ b/lib/generators/active_record/templates/remove_merit_fields_from_model.rb
@@ -1,4 +1,4 @@
-class RemoveFieldsFrom<%= table_name.camelize %> < ActiveRecord::Migration
+class RemoveMeritFieldsFrom<%= table_name.camelize %> < ActiveRecord::Migration
   def self.up
     remove_column :<%= table_name %>, :sash_id
     remove_column :<%= table_name %>, :level


### PR DESCRIPTION
Adds a "merit" label to the add/remove fields migrations to make it move obvious what they are intended for, as "Add fields to X" is too generic in a real world application.