### PR TITLE
NameError to include PointRules

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 User-visible changes worth mentioning.
 
+- [#252] Bug fix: `uninitialized constant Merit::PointRules (NameError)`.
+Fixed by rescuing the error if it occurs when there are no PointRules
+to load on boot up. 
+
 ## 2.3.3
 
 - [#215] Bug fix in API where a `BadgeSash` would be created without failures

--- a/lib/merit.rb
+++ b/lib/merit.rb
@@ -90,7 +90,8 @@ module Merit
           include Merit::ControllerExtensions
         rescue NameError => e
           # Trap NameError if installing/generating files
-          raise e unless e.to_s =~ /uninitialized constant Merit::BadgeRules/
+          raise e unless
+            e.to_s =~ /uninitialized constant Merit::(BadgeRules|PointRules)/
         end
       end
     end


### PR DESCRIPTION
modified:   `lib/merit.rb`

Add a check in case there is a `NameError` in `PointRules` as well. The check already exists for `BadgeRules`.