### PR TITLE
Test against Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,7 @@ sudo: false
 cache: bundler
 
 rvm:
-  - 2.0
-  - 2.1
-  - 2.2
+  - 2.3.0
 
 env:
-  - RAILS_VERSION=3.2
-  - RAILS_VERSION=4.1
-  - RAILS_VERSION=4.2
-
-matrix:
-  exclude:
-    - env: RAILS_VERSION=3.2
-      rvm: 2.2
+  - RAILS_VERSION=5.0

--- a/merit.gemspec
+++ b/merit.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.2'
 
-  s.add_dependency 'ambry',  '~> 0.3.0'
+  s.add_dependency 'ambry',  '~> 1.0.0'
   s.add_development_dependency 'rails', '>= 3.2.0'
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
Drops irrelevant versions of Ruby and Rails from the CI build matrix.