### PR TITLE
Fix Rails 5 sash validation fail because of required belong_to

### DIFF
--- a/lib/merit/model_additions.rb
+++ b/lib/merit/model_additions.rb
@@ -7,7 +7,7 @@ module Merit
       # That's why MeritableModel belongs_to Sash. Can't use
       # dependent: destroy as it may raise FK constraint exceptions. See:
       # https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/1079-belongs_to-dependent-destroy-should-destroy-self-before-assocation
-      belongs_to :sash, class_name: 'Merit::Sash', inverse_of: nil
+      belongs_to :sash, class_name: 'Merit::Sash', inverse_of: nil, optional: true
       attr_accessible :sash if show_attr_accessible?
 
       send :"_merit_#{Merit.orm}_specific_config"


### PR DESCRIPTION
#265 

It fails when I use `rake` to test, but works on my Rails 5 app. Also the line is over 80 characters but wasn't sure how do you prefer to break the line. 