### PR TITLE
Count performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ sudo: false
 cache: bundler
 
 rvm:
-  - 2.3.0
+  - 2.3.3
+  - 2.4.1
 
 env:
+  - RAILS_VERSION=4.2
   - RAILS_VERSION=5.0

--- a/lib/merit/model_additions.rb
+++ b/lib/merit/model_additions.rb
@@ -18,7 +18,7 @@ module Merit
 
     # Delegate methods from meritable models to their sash
     def _merit_delegate_methods_to_sash
-      methods = %w(badge_ids badges points add_badge rm_badge
+      methods = %w(badge_ids badges badge_count points add_badge rm_badge
                    add_points subtract_points score_points)
       methods.each { |method| delegate method, to: :_sash }
     end

--- a/lib/merit/models/active_record/merit/sash.rb
+++ b/lib/merit/models/active_record/merit/sash.rb
@@ -25,5 +25,9 @@ module Merit
       end
       scope
     end
+
+    def badge_count
+      badges_sashes.count
+    end
   end
 end

--- a/lib/merit/models/active_record/merit/score.rb
+++ b/lib/merit/models/active_record/merit/score.rb
@@ -7,7 +7,9 @@ module Merit
              class_name: 'Merit::Score::Point'
 
     def points
-      score_points.group(:score_id).sum(:num_points).values.first || 0
+      score_points.select('COALESCE(SUM(num_points), 0) AS num_points')
+                  .first
+                  .num_points
     end
 
     class Point < ActiveRecord::Base

--- a/lib/merit/models/active_record/merit/score.rb
+++ b/lib/merit/models/active_record/merit/score.rb
@@ -7,9 +7,9 @@ module Merit
              class_name: 'Merit::Score::Point'
 
     def points
-      score_points.select('COALESCE(SUM(num_points), 0) AS num_points')
-                  .first
-                  .num_points
+      score_points.select("COALESCE(SUM(num_points), 0) AS num_points").
+        first.
+        num_points
     end
 
     class Point < ActiveRecord::Base

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -46,6 +46,19 @@ class NavigationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'User#badge_count should return number of badges' do
+    user = User.create(name: 'test-user')
+    assert_equal [], user.badges
+
+    badge = Merit::Badge.first
+    user.add_badge badge.id
+    user.add_badge badge.id
+    assert_equal [badge, badge], user.badges
+    assert_equal [user], badge.users
+
+    assert_equal user.badge_count, 2
+  end
+
   test 'Remove inexistent badge should do nothing' do
     DummyObserver.any_instance.expects(:update).times 0
     user = User.create(name: 'test-user')

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -46,8 +46,8 @@ class NavigationTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'User#badge_count should return number of badges' do
-    user = User.create(name: 'test-user')
+  test "User#badge_count should return number of badges" do
+    user = User.create(name: "test-user")
     assert_equal [], user.badges
 
     badge = Merit::Badge.first


### PR DESCRIPTION
We have added an ActiveRecord `badge_count` method and switched the ActiveRecord `Score#points` method to avoid multiple round trips to the database. We also tested for ruby 2.3.3, ruby 2.4.1, and rails 4.2.