### PR TITLE
Run action controller load hook only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ rvm:
 
 env:
   - RAILS_VERSION=5.0.3
-  - RAILS_VERSION=5.1
+  - RAILS_VERSION=5.1.1

--- a/lib/merit.rb
+++ b/lib/merit.rb
@@ -82,7 +82,7 @@ module Merit
     initializer 'merit.controller' do |app|
       extend_orm_with_has_merit
       require_models
-      ActiveSupport.on_load(:action_controller) do
+      ActiveSupport.on_load(:action_controller, run_once: true) do
         begin
           # Load app rules on boot up
           Merit::AppBadgeRules = Merit::BadgeRules.new.defined_rules


### PR DESCRIPTION
Rails execute `action_controller` onload hooks for Both ActionController::Base and ActionController::API.

Rails [introduced](https://github.com/rails/rails/pull/30045) `has_one` option to limit executions to one

This will fix #173 for rails 5.1.4 and above