### PR TITLE
Add migration version to active record migrations

### DIFF
--- a/lib/generators/active_record/install_generator.rb
+++ b/lib/generators/active_record/install_generator.rb
@@ -28,6 +28,10 @@ module ActiveRecord
         migration_template 'create_scores_and_points.rb',
                            'db/migrate/create_scores_and_points.rb'
       end
+
+      def migration_version
+        "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+      end
     end
   end
 end

--- a/lib/generators/active_record/merit_generator.rb
+++ b/lib/generators/active_record/merit_generator.rb
@@ -16,6 +16,10 @@ module ActiveRecord
         migration_template 'add_merit_fields_to_model.rb',
                            "db/migrate/add_merit_fields_to_#{table_name}.rb"
       end
+
+      def migration_version
+        "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+      end
     end
   end
 end

--- a/lib/generators/active_record/remove_generator.rb
+++ b/lib/generators/active_record/remove_generator.rb
@@ -21,6 +21,10 @@ module ActiveRecord
           "db/migrate/remove_merit_fields_from_#{table_name}.rb"
         )
       end
+
+      def migration_version
+        "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+      end
     end
   end
 end

--- a/lib/generators/active_record/templates/add_merit_fields_to_model.rb
+++ b/lib/generators/active_record/templates/add_merit_fields_to_model.rb
@@ -1,4 +1,4 @@
-class AddMeritFieldsTo<%= table_name.camelize %> < ActiveRecord::Migration
+class AddMeritFieldsTo<%= table_name.camelize %> < ActiveRecord::Migration<%= migration_version %>
   def change
     add_column :<%= table_name %>, :sash_id, :integer
     add_column :<%= table_name %>, :level,   :integer, :default => 0

--- a/lib/generators/active_record/templates/add_target_data_to_merit_actions.rb
+++ b/lib/generators/active_record/templates/add_target_data_to_merit_actions.rb
@@ -1,4 +1,4 @@
-class AddTargetDataToMeritActions < ActiveRecord::Migration
+class AddTargetDataToMeritActions < ActiveRecord::Migration<%= migration_version %>
   def change
     add_column :merit_actions, :target_data, :text
   end

--- a/lib/generators/active_record/templates/create_badges_sashes.rb
+++ b/lib/generators/active_record/templates/create_badges_sashes.rb
@@ -1,4 +1,4 @@
-class CreateBadgesSashes < ActiveRecord::Migration
+class CreateBadgesSashes < ActiveRecord::Migration<%= migration_version %>
   def self.up
     create_table :badges_sashes do |t|
       t.integer :badge_id, :sash_id

--- a/lib/generators/active_record/templates/create_merit_actions.rb
+++ b/lib/generators/active_record/templates/create_merit_actions.rb
@@ -1,4 +1,4 @@
-class CreateMeritActions < ActiveRecord::Migration
+class CreateMeritActions < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :merit_actions do |t|
       t.integer :user_id

--- a/lib/generators/active_record/templates/create_merit_activity_logs.rb
+++ b/lib/generators/active_record/templates/create_merit_activity_logs.rb
@@ -1,4 +1,4 @@
-class CreateMeritActivityLogs < ActiveRecord::Migration
+class CreateMeritActivityLogs < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :merit_activity_logs do |t|
       t.integer  :action_id

--- a/lib/generators/active_record/templates/create_sashes.rb
+++ b/lib/generators/active_record/templates/create_sashes.rb
@@ -1,4 +1,4 @@
-class CreateSashes < ActiveRecord::Migration
+class CreateSashes < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :sashes do |t|
       t.timestamps null: false

--- a/lib/generators/active_record/templates/create_scores_and_points.rb
+++ b/lib/generators/active_record/templates/create_scores_and_points.rb
@@ -1,4 +1,4 @@
-class CreateScoresAndPoints < ActiveRecord::Migration
+class CreateScoresAndPoints < ActiveRecord::Migration<%= migration_version %>
   def change
     create_table :merit_scores do |t|
       t.references :sash

--- a/lib/generators/active_record/templates/remove_merit_fields_from_model.rb
+++ b/lib/generators/active_record/templates/remove_merit_fields_from_model.rb
@@ -1,4 +1,4 @@
-class RemoveMeritFieldsFrom<%= table_name.camelize %> < ActiveRecord::Migration
+class RemoveMeritFieldsFrom<%= table_name.camelize %> < ActiveRecord::Migration<%= migration_version %>
   def self.up
     remove_column :<%= table_name %>, :sash_id
     remove_column :<%= table_name %>, :level

--- a/lib/generators/active_record/templates/remove_merit_tables.rb
+++ b/lib/generators/active_record/templates/remove_merit_tables.rb
@@ -1,4 +1,4 @@
-class RemoveMeritTables < ActiveRecord::Migration
+class RemoveMeritTables < ActiveRecord::Migration<%= migration_version %>
   def self.up
     drop_table :merit_actions
     drop_table :merit_activity_logs

--- a/lib/generators/active_record/upgrade_generator.rb
+++ b/lib/generators/active_record/upgrade_generator.rb
@@ -19,6 +19,10 @@ module ActiveRecord
         end
       end
 
+      def migration_version
+        "[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]"
+      end
+
       private
 
       def target_data_column_doesnt_exist?


### PR DESCRIPTION
Fixes issue #278 by adding migrations versions e.g class CreateMeritActions < ActiveRecord::Migration[5.1] instead of current class CreateMeritActions < ActiveRecord::Migration

This PR fixed the review for #279 since original PR is not active. Original author name is kept in the commit credits