### PR TITLE
Update Ruby and Rails versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ sudo: false
 cache: bundler
 
 rvm:
-  - 2.3.3
-  - 2.4.1
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 
 env:
-  - RAILS_VERSION=5.0.3
-  - RAILS_VERSION=5.1.1
+  - RAILS_VERSION=5.1.6
+  - RAILS_VERSION=5.2.0

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,12 @@ source 'https://rubygems.org'
 
 gemspec
 
-version = ENV['RAILS_VERSION'] || '5.0.3'
-gem 'rails', version
+version = ENV['RAILS_VERSION']
+if version =~ /^5.2/
+  gem 'rails', github: "rails/rails", branch: "5-2-stable"
+else
+  gem 'rails', version
+end
 
 case ENV['ORM']
 when 'active_record'

--- a/merit.gemspec
+++ b/merit.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'minitest-rails'
-  s.add_development_dependency 'mocha', '1.1.0'
+  s.add_development_dependency 'mocha'
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -15,6 +15,10 @@ module Dummy
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
     # config.active_record.whitelist_attributes = true
+    if Rails.version >= "5.2"
+      Rails.application.config.active_record.sqlite3.
+        represent_boolean_as_integer = true
+    end
 
     # http://stackoverflow.com/questions/20361428/rails-i18n-validation-deprecation-warning
     config.i18n.enforce_available_locales = true

--- a/test/orm/active_record.rb
+++ b/test/orm/active_record.rb
@@ -1,2 +1,8 @@
 # Place orm-dependent test preparation here
-ActiveRecord::Migrator.migrate File.expand_path("../../dummy/db/migrate/", __FILE__)
+migrations = File.expand_path("../../dummy/db/migrate/", __FILE__)
+
+if Rails.version >= "5.2"
+  ActiveRecord::MigrationContext.new(migrations).migrate
+else
+  ActiveRecord::Migrator.migrate migrations
+end


### PR DESCRIPTION
- Drops EOL'd Rails 5.0
- Mocha doesn't need to be locked to an older version
- Fix deprecation around `ActiveRecord::ConnectionAdapters::SQLite3Adapter.represent_boolean_as_integer`
- Fix Travis CI issue: https://github.com/travis-ci/travis-ci/issues/8969
- Include fix in Rails 5-2-stable: https://github.com/rails/rails/issues/31324
