### PR TITLE
Only initialise merit when action_controller_base is loaded

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,13 +8,23 @@ end
 require 'rake/testtask'
 
 desc 'Default: run tests for all ORMs.'
-task default: :test
+task default: :run_both
+
+task run_both: [:test, :api_test]
 
 Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
   t.libs << 'test'
   t.pattern = 'test/**/*_test.rb'
   t.verbose = true
+end
+
+Rake::TestTask.new(:api_test) do |t|
+  t.libs << 'lib'
+  t.libs << 'test'
+  t.test_files = FileList['test/**/*_test.rb'].exclude(/navigation_test.rb/)
+  t.verbose = true
+  t.options = '-- -api-only=true'
 end
 
 begin

--- a/lib/merit.rb
+++ b/lib/merit.rb
@@ -82,7 +82,7 @@ module Merit
     initializer 'merit.controller' do |app|
       extend_orm_with_has_merit
       require_models
-      ActiveSupport.on_load(:action_controller, run_once: true) do
+      ActiveSupport.on_load(:action_controller_base, run_once: true) do
         begin
           # Load app rules on boot up
           Merit::AppBadgeRules = Merit::BadgeRules.new.defined_rules

--- a/lib/merit.rb
+++ b/lib/merit.rb
@@ -96,8 +96,6 @@ module Merit
       end
     end
 
-  private
-
     def require_models
       require 'merit/models/base/sash'
       require 'merit/models/base/badges_sash'
@@ -117,7 +115,11 @@ module Merit
     end
 
     def action_controller_hook
-      Rails.application.config.api_only ? :action_controller_api : :action_controller_base
+      if Rails.application.config.api_only
+        :action_controller_api
+      else
+        :action_controller_base
+      end
     end
   end
 end

--- a/lib/merit.rb
+++ b/lib/merit.rb
@@ -82,7 +82,7 @@ module Merit
     initializer 'merit.controller' do |app|
       extend_orm_with_has_merit
       require_models
-      ActiveSupport.on_load(action_controller_hook, run_once: true) do
+      ActiveSupport.on_load(action_controller_hook) do
         begin
           # Load app rules on boot up
           Merit::AppBadgeRules = Merit::BadgeRules.new.defined_rules

--- a/lib/merit.rb
+++ b/lib/merit.rb
@@ -82,7 +82,7 @@ module Merit
     initializer 'merit.controller' do |app|
       extend_orm_with_has_merit
       require_models
-      ActiveSupport.on_load(:action_controller_base, run_once: true) do
+      ActiveSupport.on_load(action_controller_hook, run_once: true) do
         begin
           # Load app rules on boot up
           Merit::AppBadgeRules = Merit::BadgeRules.new.defined_rules
@@ -95,6 +95,8 @@ module Merit
         end
       end
     end
+
+  private
 
     def require_models
       require 'merit/models/base/sash'
@@ -112,6 +114,10 @@ module Merit
       if Object.const_defined?('Mongoid')
         Mongoid::Document.send :include, Merit
       end
+    end
+
+    def action_controller_hook
+      Rails.application.config.api_only ? :action_controller_api : :action_controller_base
     end
   end
 end

--- a/test/dummy/config/application_api_only.rb
+++ b/test/dummy/config/application_api_only.rb
@@ -1,4 +1,5 @@
-require_relative 'boot'
+# frozen_string_literal: true
+require_relative "boot"
 
 require "rails"
 # Pick the frameworks you want:

--- a/test/dummy/config/application_api_only.rb
+++ b/test/dummy/config/application_api_only.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require_relative "boot"
 
 require "rails"
@@ -20,24 +21,10 @@ require "merit"
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2 if ENV['RAILS_VERSION'] =~ /^5.2/
-
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
-
-    # Only loads a smaller set of middleware suitable for API only apps.
-    # Middleware like session, flash, cookies can be added back manually.
-    # Skip views, helpers and assets when generating a new resource.
+    config.load_defaults 5.2 if ENV["RAILS_VERSION"] =~ /^5.2/
     config.api_only = true
-    # http://stackoverflow.com/questions/20361428/rails-i18n-validation-deprecation-warning
     config.i18n.enforce_available_locales = true
-
-    # Configure the default encoding used in templates for Ruby 1.9.
     config.encoding = "utf-8"
-
-    # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
   end
 end

--- a/test/dummy/config/application_api_only.rb
+++ b/test/dummy/config/application_api_only.rb
@@ -19,7 +19,7 @@ require "merit"
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
+    config.load_defaults 5.2 if ENV['RAILS_VERSION'] =~ /^5.2/
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/test/dummy/config/application_api_only.rb
+++ b/test/dummy/config/application_api_only.rb
@@ -1,0 +1,42 @@
+require_relative 'boot'
+
+require "rails"
+# Pick the frameworks you want:
+require "active_model/railtie"
+require "active_record/railtie"
+require "action_controller/railtie"
+require "action_view/railtie"
+require "action_mailer/railtie"
+
+# require "sprockets/railtie"
+require "rails/test_unit/railtie"
+
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
+Bundler.require#(*Rails.groups)
+require "merit"
+
+module Dummy
+  class Application < Rails::Application
+    # Initialize configuration defaults for originally generated Rails version.
+    config.load_defaults 5.2
+
+    # Settings in config/environments/* take precedence over those specified here.
+    # Application configuration can go into files in config/initializers
+    # -- all .rb files in that directory are automatically loaded after loading
+    # the framework and any gems in your application.
+
+    # Only loads a smaller set of middleware suitable for API only apps.
+    # Middleware like session, flash, cookies can be added back manually.
+    # Skip views, helpers and assets when generating a new resource.
+    config.api_only = true
+    # http://stackoverflow.com/questions/20361428/rails-i18n-validation-deprecation-warning
+    config.i18n.enforce_available_locales = true
+
+    # Configure the default encoding used in templates for Ruby 1.9.
+    config.encoding = "utf-8"
+
+    # Configure sensitive parameters which will be filtered from the log file.
+    config.filter_parameters += [:password]
+  end
+end

--- a/test/dummy/config/application_api_only.rb
+++ b/test/dummy/config/application_api_only.rb
@@ -13,13 +13,13 @@ require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
-Bundler.require#(*Rails.groups)
+Bundler.require
 require "merit"
 
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/test/dummy/config/environment_api_only.rb
+++ b/test/dummy/config/environment_api_only.rb
@@ -1,0 +1,5 @@
+# Load the rails application
+require File.expand_path('../application_api_only', __FILE__)
+
+# Initialize the rails application
+Dummy::Application.initialize!

--- a/test/dummy/config/environment_api_only.rb
+++ b/test/dummy/config/environment_api_only.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
 # Load the rails application
-require File.expand_path('../application_api_only', __FILE__)
+require File.expand_path("application_api_only",  __dir__)
 
 # Initialize the rails application
 Dummy::Application.initialize!

--- a/test/dummy/config/environment_api_only.rb
+++ b/test/dummy/config/environment_api_only.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
+
 # Load the rails application
-require File.expand_path("application_api_only",  __dir__)
+require File.expand_path("application_api_only", __dir__)
 
 # Initialize the rails application
 Dummy::Application.initialize!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,8 @@
 # Configure Rails Envinronment
 ENV['RAILS_ENV'] = 'test'
-RUBYOPT = "-w $RUBYOPT"
+RUBYOPT = "-w $RUBYOPT".freeze
 
-API_ONLY = ARGV.include?('-api-only=true')
+API_ONLY = ARGV.include?("-api-only=true").freeze
 
 if ENV["COVERAGE"]
   require 'coveralls'
@@ -21,9 +21,9 @@ if ENV["COVERAGE"]
 end
 
 if API_ONLY
-  require File.expand_path("dummy/config/environment_api_only.rb",  __dir__)
+  require File.expand_path("dummy/config/environment_api_only.rb", __dir__)
 else
-  require File.expand_path("dummy/config/environment.rb",  __dir__)
+  require File.expand_path("dummy/config/environment.rb", __dir__)
 end
 
 require "rails/test_help"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,8 @@
 # Configure Rails Envinronment
 ENV['RAILS_ENV'] = 'test'
-RUBYOPT="-w $RUBYOPT"
+RUBYOPT = "-w $RUBYOPT"
 
-API_ONLY=ARGV.include?('-api-only=true')
+API_ONLY = ARGV.include?('-api-only=true')
 
 if ENV["COVERAGE"]
   require 'coveralls'
@@ -21,14 +21,14 @@ if ENV["COVERAGE"]
 end
 
 if API_ONLY
-  require File.expand_path('../dummy/config/environment_api_only.rb', __FILE__)
+  require File.expand_path("dummy/config/environment_api_only.rb",  __dir__)
 else
-  require File.expand_path('../dummy/config/environment.rb', __FILE__)
+  require File.expand_path("dummy/config/environment.rb",  __dir__)
 end
 
-require 'rails/test_help'
-require 'minitest/rails'
-require 'mocha/minitest'
+require "rails/test_help"
+require "minitest/rails"
+require "mocha/minitest"
 require "orm/#{Merit.orm}"
 
 Rails.backtrace_cleaner.remove_silencers!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,8 @@
 ENV['RAILS_ENV'] = 'test'
 RUBYOPT="-w $RUBYOPT"
 
+API_ONLY=ARGV.include?('-api-only=true')
+
 if ENV["COVERAGE"]
   require 'coveralls'
   require 'simplecov'
@@ -18,10 +20,15 @@ if ENV["COVERAGE"]
   SimpleCov.start 'rubygem'
 end
 
-require File.expand_path('../dummy/config/environment.rb', __FILE__)
+if API_ONLY
+  require File.expand_path('../dummy/config/environment_api_only.rb', __FILE__)
+else
+  require File.expand_path('../dummy/config/environment.rb', __FILE__)
+end
+
 require 'rails/test_help'
 require 'minitest/rails'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require "orm/#{Merit.orm}"
 
 Rails.backtrace_cleaner.remove_silencers!


### PR DESCRIPTION
Previously merit was initialised when action_controller was loaded,
which if you are using the Rails API & Web functions meant that it was
loaded once, but could be loaded by the API OR Web bits being
initialised. Thanks to the Rails PR listed below, you can now hook in to
the web part only being initialised using action_controller_base
https://github.com/rails/rails/pull/28402