### PR TITLE
Fixed finder method

### DIFF
--- a/app/models/merit/badge.rb
+++ b/app/models/merit/badge.rb
@@ -18,7 +18,7 @@ module Merit
       end
 
       def by_name(name)
-        find { |b| b.name == name.to_s }
+        find { |b| b.name.to_s == name.to_s }
       end
 
       def by_level(level)

--- a/test/unit/rule_unit_test.rb
+++ b/test/unit/rule_unit_test.rb
@@ -35,10 +35,17 @@ describe Merit::Rule do
       -> { @rule.badge }.must_raise Merit::BadgeNotFound
     end
 
-    it 'finds related badge by name' do
+    it 'finds related badge by name, when the name is a string' do
       Merit::Badge.create(id: 98, name: 'test-badge-98')
       @rule.badge_name = "test-badge-98"
       @rule.badge.must_be :==, Merit::Badge.find(98)
+    end
+
+    it 'finds related badge by name, when the name is a symbol' do
+      Merit::Badge.create(id: 100, name: :testbadge)
+      @rule.badge_name = 'testbadge'
+      @rule.badge.must_be :==, Merit::Badge.find(100)
+      @rule.badge
     end
 
     it 'finds related badge by name' do


### PR DESCRIPTION
* Added `.to_s` on `Merit::Badge#by_name`, so the method will always compare strings, even when
we define badge names as symbols.