### PR TITLE
Replace update attributes with update and add new ruby version builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,3 @@ rvm:
 env:
   - RAILS_VERSION=5.1.6
   - RAILS_VERSION=5.2.0
-  - RAILS_VERSION=6.0.0.beta1

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ cache: bundler
 rvm:
   - 2.3.7
   - 2.4.4
-  - 2.5.1
+  - 2.5.3
+  - 2.6.1
 
 env:
   - RAILS_VERSION=5.1.6
   - RAILS_VERSION=5.2.0
+  - RAILS_VERSION=6.0.0.beta1

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ if version =~ /^5.2/
   gem 'rails', github: "rails/rails", branch: "5-2-stable"
 else
   gem 'rails', version
-  gem 'sqlite3', '~> 1.3.13'
 end
 
 case ENV['ORM']
@@ -19,7 +18,7 @@ end
 
 group :development, :test do
   gem 'activerecord-jdbcsqlite3-adapter', :platforms => [:jruby]
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.13'
 end
 
 gem 'coveralls', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ if version =~ /^5.2/
   gem 'rails', github: "rails/rails", branch: "5-2-stable"
 else
   gem 'rails', version
+  gem 'sqlite3', '~> 1.3.13'
 end
 
 case ENV['ORM']

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ gemspec
 version = ENV['RAILS_VERSION']
 if version =~ /^5.2/
   gem 'rails', github: "rails/rails", branch: "5-2-stable"
-elsif version =~/^6.0/
-  gem 'rails', "~> 6.0.0.beta1"
 else
   gem 'rails', version
 end
@@ -20,7 +18,7 @@ end
 
 group :development, :test do
   gem 'activerecord-jdbcsqlite3-adapter', :platforms => [:jruby]
-  gem 'sqlite3', '~> 1.3.6'
+  gem 'sqlite3'
 end
 
 gem 'coveralls', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ gemspec
 version = ENV['RAILS_VERSION']
 if version =~ /^5.2/
   gem 'rails', github: "rails/rails", branch: "5-2-stable"
+elsif version =~/^6.0/
+  gem 'rails', "~> 6.0.0.beta1"
 else
   gem 'rails', version
 end
@@ -18,7 +20,7 @@ end
 
 group :development, :test do
   gem 'activerecord-jdbcsqlite3-adapter', :platforms => [:jruby]
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3.6'
 end
 
 gem 'coveralls', require: false

--- a/lib/merit/model_additions.rb
+++ b/lib/merit/model_additions.rb
@@ -50,7 +50,7 @@ module Merit
     def _merit_sash_initializer
       define_method(:_sash) do
         # TODO: reload.sash is not regression tested
-        sash || reload.sash || update_attributes(sash: Sash.create)
+        sash || reload.sash || update(sash: Sash.create)
         sash
       end
     end

--- a/test/dummy/app/controllers/comments_controller.rb
+++ b/test/dummy/app/controllers/comments_controller.rb
@@ -33,7 +33,7 @@ class CommentsController < ApplicationController
 
   def update
     @comment = Comment.find(params[:id])
-    if @comment.update_attributes(comment_params)
+    if @comment.update(comment_params)
       redirect_to(@comment, :notice => 'Comment was successfully updated.')
     else
       render "edit"

--- a/test/dummy/app/controllers/registrations_controller.rb
+++ b/test/dummy/app/controllers/registrations_controller.rb
@@ -3,7 +3,7 @@ class RegistrationsController < ApplicationController
     @user = User.find(params[:id])
 
     respond_to do |format|
-      if @user.update_attributes(user_params)
+      if @user.update(user_params)
         format.html { redirect_to(@user, :notice => 'User was successfully updated.') }
         format.xml  { head :ok }
       else


### PR DESCRIPTION
Rails 6.0 deprecation notice - that update_attributes will be deprecated. Replace calls with update - https://github.com/rails/rails/pull/31998

```DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1```