### PR TITLE
Use find_each in Merit::Action.check_unprocessed

### DIFF
--- a/app/models/merit/action.rb
+++ b/app/models/merit/action.rb
@@ -15,9 +15,7 @@ require_dependency "merit/models/#{Merit.orm}/merit/action"
 module Merit
   class Action
     def self.check_unprocessed
-      where(processed: false).find_each do |merit_action|
-        mert_action.check_all_rules
-      end
+      where(processed: false).find_each(&:check_all_rules)
     end
 
     # Check rules defined for a merit_action

--- a/app/models/merit/action.rb
+++ b/app/models/merit/action.rb
@@ -15,7 +15,9 @@ require_dependency "merit/models/#{Merit.orm}/merit/action"
 module Merit
   class Action
     def self.check_unprocessed
-      where(processed: false).map(&:check_all_rules)
+      where(processed: false).find_each do |merit_action|
+        mert_action.check_all_rules
+      end
     end
 
     # Check rules defined for a merit_action


### PR DESCRIPTION
Use find_each to load records in batches. This will use much less memory and dramatically speed up the query.