### PR TITLE
Test against Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ sudo: false
 cache: bundler
 
 rvm:
-  - 2.3.7
-  - 2.4.4
-  - 2.5.3
-  - 2.6.1
+  - 2.5
+  - 2.6
 
 env:
-  - RAILS_VERSION=5.1.6
-  - RAILS_VERSION=5.2.0
+  - RAILS_VERSION=5.1
+  - RAILS_VERSION=5.2
+  - RAILS_VERSION=6.0

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-version = ENV['RAILS_VERSION']
-if version =~ /^5.2/
-  gem 'rails', github: "rails/rails", branch: "5-2-stable"
-else
-  gem 'rails', version
-end
+gem 'rails', "~> #{ENV.fetch('RAILS_VERSION', 6.0)}"
 
 case ENV['ORM']
 when 'active_record'
@@ -18,7 +13,7 @@ end
 
 group :development, :test do
   gem 'activerecord-jdbcsqlite3-adapter', :platforms => [:jruby]
-  gem 'sqlite3', '~> 1.3.13'
+  gem 'sqlite3', '~> 1.4'
 end
 
 gem 'coveralls', require: false

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,11 @@ end
 require 'rake/testtask'
 
 desc 'Default: run tests for all ORMs.'
-task default: [:test, :api_test]
+task default: [:setup, :test, :api_test]
+
+task :setup do
+  system "cd test/dummy && rake db:migrate && rake db:test:prepare"
+end
 
 Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'

--- a/lib/merit/model_additions.rb
+++ b/lib/merit/model_additions.rb
@@ -8,7 +8,6 @@ module Merit
       # dependent: destroy as it may raise FK constraint exceptions. See:
       # https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/1079-belongs_to-dependent-destroy-should-destroy-self-before-assocation
       belongs_to :sash, class_name: 'Merit::Sash', inverse_of: nil, optional: true
-      attr_accessible :sash if show_attr_accessible?
 
       send :"_merit_#{Merit.orm}_specific_config"
       _merit_delegate_methods_to_sash
@@ -36,11 +35,6 @@ module Merit
     def _merit_define_badge_related_entries_method
       meritable_class_name = name.demodulize
       Merit::Badge._define_related_entries_method(meritable_class_name)
-    end
-
-    def show_attr_accessible?
-      defined?(ProtectedAttributes) ||
-        !defined?(ActionController::StrongParameters)
     end
 
     # _sash initializes a sash if doesn't have one yet.

--- a/lib/merit/models/active_record/merit/action.rb
+++ b/lib/merit/models/active_record/merit/action.rb
@@ -3,10 +3,5 @@ module Merit
     self.table_name = :merit_actions
 
     has_many :activity_logs, class_name: 'Merit::ActivityLog'
-
-    if show_attr_accessible?
-      attr_accessible :user_id, :action_method, :action_value, :had_errors,
-                      :target_model, :target_id, :processed, :log, :target_data
-    end
   end
 end

--- a/lib/merit/models/active_record/merit/activity_log.rb
+++ b/lib/merit/models/active_record/merit/activity_log.rb
@@ -5,9 +5,5 @@ module Merit
     belongs_to :action, class_name: 'Merit::Action'
     belongs_to :related_change, polymorphic: true, optional: true
     has_one :sash, through: :related_change
-
-    if show_attr_accessible?
-      attr_accessible :action_id, :related_change, :description, :created_at
-    end
   end
 end

--- a/lib/merit/models/active_record/merit/badges_sash.rb
+++ b/lib/merit/models/active_record/merit/badges_sash.rb
@@ -7,7 +7,5 @@ module Merit
              as: :related_change
 
     validates_presence_of :badge_id, :sash
-
-    attr_accessible :badge_id if show_attr_accessible?
   end
 end

--- a/lib/merit/models/mongoid/merit/badges_sash.rb
+++ b/lib/merit/models/mongoid/merit/badges_sash.rb
@@ -6,8 +6,6 @@ module Merit
 
     field :badge_id,      type: Integer
 
-    attr_accessible :badge_id if show_attr_accessible?
-
     belongs_to :sash, class_name: 'Merit::Sash'
     has_many :activity_logs, class_name: 'Merit::ActivityLog', as: :related_change
 

--- a/test/dummy/app/models/comment.rb
+++ b/test/dummy/app/models/comment.rb
@@ -25,10 +25,6 @@ class Comment
 
   belongs_to :user
 
-  if show_attr_accessible?
-    attr_accessible :name, :comment, :user_id, :votes
-  end
-
   validates :name, :comment, :user_id, :presence => true
 
   delegate :comments, :to => :user, :prefix => true

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -17,10 +17,6 @@ class User
   has_many :addresses
   has_many :comments
 
-  if show_attr_accessible?
-    attr_accessible :name
-  end
-
   def model_with_no_reputation
     addresses.first || addresses.create
   end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -11,7 +11,7 @@ require "merit"
 
 module Dummy
   class Application < Rails::Application
-    if Rails.version >= "5.2"
+    if Rails.version.match? "5.2.+"
       config.active_record.sqlite3.represent_boolean_as_integer = true
     end
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,93 +1,94 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140906225844) do
+ActiveRecord::Schema.define(version: 2014_09_06_225844) do
 
-  create_table "addresses", force: true do |t|
+  create_table "addresses", force: :cascade do |t|
     t.integer "user_id"
+    t.index ["user_id"], name: "index_addresses_on_user_id"
   end
 
-  create_table "badges_sashes", force: true do |t|
-    t.integer  "badge_id"
-    t.integer  "sash_id"
-    t.boolean  "notified_user", default: false
-    t.datetime "created_at"
-  end
-
-  add_index "badges_sashes", ["badge_id", "sash_id"], name: "index_badges_sashes_on_badge_id_and_sash_id"
-  add_index "badges_sashes", ["badge_id"], name: "index_badges_sashes_on_badge_id"
-  add_index "badges_sashes", ["sash_id"], name: "index_badges_sashes_on_sash_id"
-
-  create_table "comments", force: true do |t|
-    t.string   "name"
-    t.text     "comment"
-    t.integer  "user_id"
-    t.integer  "votes",      default: 0
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.integer  "sash_id"
-    t.integer  "level",      default: 0
-  end
-
-  create_table "merit_actions", force: true do |t|
-    t.integer  "user_id"
-    t.string   "action_method"
-    t.integer  "action_value"
-    t.boolean  "had_errors",    default: false
-    t.string   "target_model"
-    t.integer  "target_id"
-    t.boolean  "processed",     default: false
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
-    t.text     "target_data"
-  end
-
-  create_table "merit_activity_logs", force: true do |t|
-    t.integer  "action_id"
-    t.string   "related_change_type"
-    t.integer  "related_change_id"
-    t.string   "description"
-    t.datetime "created_at"
-  end
-
-  create_table "merit_score_points", force: true do |t|
-    t.integer  "score_id"
-    t.integer  "num_points", default: 0
-    t.string   "log"
-    t.datetime "created_at"
-  end
-
-  create_table "merit_scores", force: true do |t|
+  create_table "badges_sashes", force: :cascade do |t|
+    t.integer "badge_id"
     t.integer "sash_id"
-    t.string  "category", default: "default"
+    t.boolean "notified_user", default: false
+    t.datetime "created_at"
+    t.index ["badge_id", "sash_id"], name: "index_badges_sashes_on_badge_id_and_sash_id"
+    t.index ["badge_id"], name: "index_badges_sashes_on_badge_id"
+    t.index ["sash_id"], name: "index_badges_sashes_on_sash_id"
   end
 
-  create_table "players", force: true do |t|
+  create_table "comments", force: :cascade do |t|
+    t.string "name"
+    t.text "comment"
+    t.integer "user_id"
+    t.integer "votes", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "sash_id"
-    t.integer "level",   default: 0
+    t.integer "level", default: 0
   end
 
-  create_table "sashes", force: true do |t|
+  create_table "merit_actions", force: :cascade do |t|
+    t.integer "user_id"
+    t.string "action_method"
+    t.integer "action_value"
+    t.boolean "had_errors", default: false
+    t.string "target_model"
+    t.integer "target_id"
+    t.boolean "processed", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "target_data"
+  end
+
+  create_table "merit_activity_logs", force: :cascade do |t|
+    t.integer "action_id"
+    t.string "related_change_type"
+    t.integer "related_change_id"
+    t.string "description"
+    t.datetime "created_at"
+  end
+
+  create_table "merit_score_points", force: :cascade do |t|
+    t.integer "score_id"
+    t.integer "num_points", default: 0
+    t.string "log"
+    t.datetime "created_at"
+    t.index ["score_id"], name: "index_merit_score_points_on_score_id"
+  end
+
+  create_table "merit_scores", force: :cascade do |t|
+    t.integer "sash_id"
+    t.string "category", default: "default"
+    t.index ["sash_id"], name: "index_merit_scores_on_sash_id"
+  end
+
+  create_table "players", force: :cascade do |t|
+    t.integer "sash_id"
+    t.integer "level", default: 0
+  end
+
+  create_table "sashes", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "users", force: true do |t|
-    t.string   "name"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.integer  "sash_id"
-    t.integer  "level",      default: 0
+  create_table "users", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "sash_id"
+    t.integer "level", default: 0
   end
 
 end

--- a/test/orm/active_record.rb
+++ b/test/orm/active_record.rb
@@ -1,8 +1,0 @@
-# Place orm-dependent test preparation here
-migrations = File.expand_path("../../dummy/db/migrate/", __FILE__)
-
-if Rails.version >= "5.2"
-  ActiveRecord::MigrationContext.new(migrations).migrate
-else
-  ActiveRecord::Migrator.migrate migrations
-end

--- a/test/orm/mongoid.rb
+++ b/test/orm/mongoid.rb
@@ -1,6 +1,0 @@
-# Place orm-dependent test preparation here
-class ActiveSupport::TestCase
-  setup do
-    Mongoid.purge!
-  end
-end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,7 +27,6 @@ end
 require "rails/test_help"
 require "minitest/rails"
 require "mocha/minitest"
-require "orm/#{Merit.orm}"
 
 Rails.backtrace_cleaner.remove_silencers!
 
@@ -40,7 +39,3 @@ Capybara.default_selector = :css
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 Merit.orm = :active_record if Merit.orm.nil?
-
-def active_record_orm?
-  Merit.orm == :active_record
-end

--- a/test/unit/merit_unit_test.rb
+++ b/test/unit/merit_unit_test.rb
@@ -14,17 +14,15 @@ class MeritUnitTest < ActiveSupport::TestCase
     assert Merit::Badge.method_defined?(:players), 'Badge#players should be defined'
   end
 
-  if active_record_orm?
-    test 'unknown ranking raises exception' do
-      class WeirdRankRules
-        include Merit::RankRulesMethods
-        def initialize
-          set_rank level: 1, to: Player, level_name: :clown
-        end
+  test 'unknown ranking raises exception' do
+    class WeirdRankRules
+      include Merit::RankRulesMethods
+      def initialize
+        set_rank level: 1, to: Player, level_name: :clown
       end
-      assert_raises Merit::RankAttributeNotDefined do
-        WeirdRankRules.new.check_rank_rules
-      end
+    end
+    assert_raises Merit::RankAttributeNotDefined do
+      WeirdRankRules.new.check_rank_rules
     end
   end
 


### PR DESCRIPTION
- Drops `attr_accessible` pre-Rails 5 syntax
- Drops testing scaffold for Mongoid
- Drop patch versions for Ruby and Rails from travis configuration
- Drop testing with EOL'd Ruby 2.3 and security maintenance 2.4