### PR TITLE
Fix typo in active_record/merit_generator.rb

### DIFF
--- a/lib/merit/generators/active_record/merit_generator.rb
+++ b/lib/merit/generators/active_record/merit_generator.rb
@@ -13,7 +13,7 @@ module Merit
       end
 
       def copy_migrations_and_model
-        migration_template 'add_merit_fields_to_model.rb',
+        migration_template 'add_merit_fields_to_model.erb',
                            "db/migrate/add_merit_fields_to_#{table_name}.rb"
       end
 


### PR DESCRIPTION
Line#16 of the `lib/merit/generators/active_record/merit_generator.rb` class was referring to the migration_template source as 'add_merit_fields_to_model.rb'. This source does not exist as the actual extension is `.erb`. This caused the task to fail as there is no template with the name 'add_merit_fields_to_model.rb'.

Resolving: https://github.com/merit-gem/merit/issues/344

**Working example:**
```
root@b16ac38735ed:/app# rails g merit:active_record:merit lectures
Running via Spring preloader in process 354
      create  db/migrate/20200613030255_add_merit_fields_to_lectures.rb
```

**Generated template:**
```
root@b16ac38735ed:/app# cat db/migrate/20200613030255_add_merit_fields_to_lectures.rb
class AddMeritFieldsToLectures < ActiveRecord::Migration[6.0]
  def change
    add_column :lectures, :sash_id, :integer
    add_column :lectures, :level,   :integer, :default => 0
  end
end
```