### PR TITLE
Correct typo in initializer template

### DIFF
--- a/lib/merit/generators/templates/merit.erb
+++ b/lib/merit/generators/templates/merit.erb
@@ -6,7 +6,7 @@ Merit.setup do |config|
   # Add application observers to get notifications when reputation changes.
   # config.add_observer 'MyObserverClassName'
 
-  # Define :user_model_name. This model will be used to grand badge if no
+  # Define :user_model_name. This model will be used to grant badge if no
   # `:to` option is given. Default is 'User'.
   # config.user_model_name = 'User'
 


### PR DESCRIPTION
will be used to grand badge => will be used to grant badge