### PR TITLE
Remove :orm hooks

### DIFF
--- a/lib/merit/generators/install_generator.rb
+++ b/lib/merit/generators/install_generator.rb
@@ -4,7 +4,6 @@ module Merit
   module Generators
     class InstallGenerator < ::Rails::Generators::Base
       source_root File.expand_path('../templates', __FILE__)
-      hook_for :orm
 
       desc 'Copy config and rules files'
       def copy_migrations_and_model

--- a/lib/merit/generators/merit_generator.rb
+++ b/lib/merit/generators/merit_generator.rb
@@ -4,7 +4,6 @@ module Merit
   module Generators
     class MeritGenerator < ::Rails::Generators::NamedBase
       source_root File.expand_path('../templates', __FILE__)
-      hook_for :orm
 
       def inject_merit_content
         if model_exists?

--- a/lib/merit/generators/remove_generator.rb
+++ b/lib/merit/generators/remove_generator.rb
@@ -4,7 +4,6 @@ module Merit
   module Generators
     class RemoveGenerator < ::Rails::Generators::NamedBase
       source_root File.expand_path('../templates', __FILE__)
-      hook_for :orm
 
       private
 


### PR DESCRIPTION
Remove :orm hooks for the (now) unsupported generator options which
were causing deprecation notices in thor versions > 1.0.0.