### PR TITLE
Fix merit_actions migration template

### DIFF
--- a/lib/merit/generators/active_record/templates/create_merit_actions.erb
+++ b/lib/merit/generators/active_record/templates/create_merit_actions.erb
@@ -11,7 +11,7 @@ class CreateMeritActions < ActiveRecord::Migration<%= migration_version %>
       t.boolean :processed, default: false
       t.timestamps null: false
     end
-  end
 
-  add_index :merit_actions, :processed
+    add_index :merit_actions, :processed
+  end
 end


### PR DESCRIPTION
If `add_index` call is outside the `def change` method definition, it's executed right away, and:

    Caused by:
    ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:  relation "merit_actions" does not exist