### PR TITLE
add run_once to ActiveSupport on_load

### DIFF
--- a/lib/merit.rb
+++ b/lib/merit.rb
@@ -62,7 +62,7 @@ module Merit
 
     initializer 'merit.controller' do |app|
       config.to_prepare do
-        ActiveSupport.on_load(:active_record) { include Merit }
+        ActiveSupport.on_load(:active_record, run_once: true) { include Merit }
         ActiveSupport.on_load(app.config.api_only ? :action_controller_api : :action_controller_base) do
           begin
             # Load app rules on boot up


### PR DESCRIPTION
closes #360

We are experiencing long reloads in our App whenever we are updating code. 
This PR add a run_once option the the rules loader.

We have tested our codebase with this branch and it improves a lot our developer experience.

maybe @ephracis you can test too to see if it solves your initial issue