### PR TITLE
Fix: warning: previous definition messages

### DIFF
--- a/lib/merit.rb
+++ b/lib/merit.rb
@@ -35,6 +35,16 @@ module Merit
     @config.add_observer(class_name)
   end
 
+  # If the app is reloaded, avoid printing `warning: previous definition of AppBadgeRules was here`
+  def self.remove_badge_rules
+    remove_const(:AppBadgeRules) if self.const_defined?('AppBadgeRules')
+  end
+
+  # If the app is reloaded, avoid printing `warning: previous definition of AppPointRules was here`
+  def self.remove_point_rules
+    remove_const(:AppPointRules) if self.const_defined?('AppPointRules')
+  end
+
   class Configuration
     attr_accessor :checks_on_each_request, :orm, :user_model_name, :observers,
                   :current_user_method
@@ -65,6 +75,9 @@ module Merit
         ActiveSupport.on_load(:active_record) { include Merit }
         ActiveSupport.on_load(app.config.api_only ? :action_controller_api : :action_controller_base) do
           begin
+            # Remove previous definitions of constant if they are defined when app reloads
+            Merit.remove_badge_rules
+            Merit.remove_point_rules
             # Load app rules on boot up
             Merit::AppBadgeRules = Merit::BadgeRules.new.defined_rules
             Merit::AppPointRules = Merit::PointRules.new.defined_rules

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -2,8 +2,8 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.


### PR DESCRIPTION
Issue: https://github.com/merit-gem/merit/issues/173

When app reload is triggered, following warnings were spamming the console, especially running DelayedJob which reloads app every 5 seconds when running:

Fix:
If the constants are already defined, remove them first before setting again