### PR TITLE
Fix warning: add observer as runtime dependency

### DIFF
--- a/merit.gemspec
+++ b/merit.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'ambry', '~> 1.0.0'
   s.add_runtime_dependency 'zeitwerk'
+  s.add_runtime_dependency 'observer'
 
   s.add_development_dependency 'rails', '>= 5.1.6'
   s.add_development_dependency 'capybara'


### PR DESCRIPTION
Hello, 

Fix of the following warning : `observer` won't be part of the default gems with ruby 3.4

```
/usr/local/bundle/gems/zeitwerk-2.6.16/lib/zeitwerk/kernel.rb:34: warning: observer was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add observer to your Gemfile or gemspec. Also contact author of merit-4.0.3 to add observer into its gemspec.
```